### PR TITLE
do not prepend http urls with absolute paths

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ export const firstWorkspaceDirectory = () =>
   vscode.workspace.workspaceFolders![0].uri.fsPath
 
 const makePathAbsolute = (fsPath: string): string => {
-  if (path.isAbsolute(fsPath)) {
+  if (path.isAbsolute(fsPath) || fsPath.startsWith('http')) {
     return fsPath
   }
   return path.join(firstWorkspaceDirectory(), fsPath)


### PR DESCRIPTION
Hi @capaj,

Thanks for the extension! At the moment all schema paths are prepended with absolute paths, even HTTP urls like `http://localhost:4000`. It makes the extension fail. This tiny PR should fix the problem.