### PR TITLE
Add user configurability for file extensions and watched file path

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
           "type": "[string]",
           "default": ["graphql", "gql"],
           "description": "GraphQL Codegen will automatically re-run codegen when files matching these file extensions are saved."
-        }
+        },
         "graphql-codegen.filePathToListen": {
           "type": ["string", "null"],
           "default": null,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,22 @@
         "command": "graphql-codegen.generateGqlCodegen",
         "title": "Generate GQL codegen"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "GraphQL Codegen",
+      "properties": {
+        "graphql-codegen.fileExtensionsDeclaringGraphQLDocuments": {
+          "type": "[string]",
+          "default": ["graphql", "gql"],
+          "description": "GraphQL Codegen will automatically re-run codegen when files matching these file extensions are saved."
+        }
+        "graphql-codegen.filePathToListen": {
+          "type": ["string", "null"],
+          "default": null,
+          "description": "If specified, GraphQL Codegen will only re-run codegen if the files match the specified regex path."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "tsc -p ./ --skipLibCheck",

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
           "default": ["graphql", "gql"],
           "description": "GraphQL Codegen will automatically re-run codegen when files matching these file extensions are saved."
         },
-        "graphql-codegen.filePathToListen": {
+        "graphql-codegen.filePathToWatch": {
           "type": ["string", "null"],
           "default": null,
-          "description": "If specified, GraphQL Codegen will only re-run codegen if the files match the specified regex path."
+          "markdownDescription": "If specified, GraphQL Codegen will only re-run codegen if the files match the specified glob path. Uses [minimatch](https://github.com/isaacs/minimatch) glob syntax."
         }
       }
     }


### PR DESCRIPTION
Hi @capaj, this extension rocks – really interested in using it for my project, but our team declares our graphql directly inside of our `ts` or `tsx` files. so i'd like to add a couple settings to allow this:

- `"graphql-codegen.fileExtensionsDeclaringGraphQLDocuments"`: change which file extensions are watched for saves. currently this is hardcoded to `graphql` and `gql`.
- `"graphql-codegen.filePathToWatch"`: allow users to specify a file path that files should match before running codegen. this is important as users could specify a more broad file (eg `ts`) that could exist in both paths relevant to graphql generation and paths that are not.