### PR TITLE
Add configFilePath option to set a path to a custom configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Keep in mind it will only run when your node_modules contains `@graphql-codegen/
 
 - `"graphql-codegen.fileExtensionsDeclaringGraphQLDocuments"`: change which file extensions are watched for saves. Defaults to `graphql` and `gql`. If you just use these files to define your mutations you don't need to configure anything.
 - `"graphql-codegen.filePathToWatch"`: allow users to specify a multimatch patters that file paths should match before running codegen. This is important as users could specify a more broad file (eg `ts`) that could exist in both paths relevant to graphql generation and paths that are not. Defaults to `null`, so watches everything.
+- `"graphql-codegen.configFilePath"`: allow users to specify a path to the codegen configuration file. Defaults to `codegen.yml`.
 
 ### How is it different than VilvaAthibanPB.graphql-codegen
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,14 @@
           ],
           "default": null,
           "markdownDescription": "If specified, GraphQL Codegen will only re-run codegen if the files match the specified glob path. Uses [minimatch](https://github.com/isaacs/minimatch) glob syntax."
+        },
+        "graphql-codegen.configFilePath": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "markdownDescription": "Path to the codegen configuration file"
         }
       }
     }


### PR DESCRIPTION
I'd like to add this settings :

- `"graphql-codegen.configFilePath"`: allow users to specify a path to the codegen configuration file. Defaults to `codegen.yml`.