### PR TITLE
fix error message

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -215,11 +215,15 @@ async function runCliGenerateWithUINotifications(
 
     vscode.window.showInformationMessage(`codegen ${file} done!`)
   } catch (err) {
-    vscode.window.showErrorMessage(
-      `Codegen threw ${err.errors.length} ${
-        err.errors.length === 1 ? 'error' : 'errors'
-      }, first one: ${err.errors[0].message}`
-    )
+    if (err.errors?.length) {
+      vscode.window.showErrorMessage(
+        `Codegen threw ${err.errors.length} ${
+          err.errors.length === 1 ? 'error' : 'errors'
+        }, first one: ${err.errors[0].message}`
+      )
+    } else {
+      vscode.window.showErrorMessage(`Codegen threw error: ${err.message}`)
+    }
   }
 }
 


### PR DESCRIPTION
Sometimes error isn't an array. For example, when hooks failed, error is a default error. 