### PR TITLE
Fix type for the fileExtensionsDeclaringGraphQLDocuments setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
       "title": "GraphQL Codegen",
       "properties": {
         "graphql-codegen.fileExtensionsDeclaringGraphQLDocuments": {
-          "type": "[string]",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "default": [
             "graphql",
             "gql"


### PR DESCRIPTION
The type `"[string]"` isn't valid, this is the way to set an option as array.