### PR TITLE
Add `workspaceContains:package.json` activationEvent

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "main": "./dist/graphql-codegen-vscode.js",
   "activationEvents": [
     "onLanguage:graphql",
-    "onLanguage:GraphQL"
+    "onLanguage:GraphQL",
+    "workspaceContains:package.json"
   ],
   "contributes": {
     "commands": [


### PR DESCRIPTION
The project I'm building does not contain specific graphql files. We instead embed the graphql in a typescript file so we would have to create a file just to activate this plugin. This solves that issue.